### PR TITLE
id is not always defined in tickets’ calling

### DIFF
--- a/class/actions_doliproject.class.php
+++ b/class/actions_doliproject.class.php
@@ -523,7 +523,7 @@ class ActionsDoliproject
 				$task           = new Task($this->db);
 				$ticket         = new Ticket($this->db);
 
-				$ticket->fetch(GETPOST('id'));
+				$ticket->fetch(!empty(GETPOST('id')) ? (GETPOST('id')) : '', !empty(GETPOST('ref')) ? GETPOST('ref') : '', !empty(GETPOST('track_id')) ? GETPOST('track_id') : '');
 				$ticket->fetch_optionals();
 
 				$task_id = $ticket->array_options['options_fk_task'];


### PR DESCRIPTION
Afin d’éviter une vilaine erreur dans le pied de page, ceci permet de considérer le ticket depuis sa réf ou son track_id